### PR TITLE
Use subscription to notify about project views

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const {posthookReceiver} = require('./webhooks/posthookReceiver');
 const {scheduleDailyMails} = require('./webhooks/scheduleDailyMails');
 const {updateIntercom} = require('./webhooks/updateIntercom');
 const {subscribeToUpdateIntercom} = require('./intercomTracking');
+const {notifyViewedProject} = require('./notifyViewedProject');
 
 const {PORT} = process.env;
 
@@ -67,3 +68,4 @@ else {
 }
 
 subscribeToUpdateIntercom(prisma);
+notifyViewedProject(prisma);

--- a/notifyViewedProject.js
+++ b/notifyViewedProject.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-await-in-loop */
+
+const moment = require('moment');
+
+const gql = String.raw;
+
+async function notifyViewedProject(prisma) {
+	const subscription = await prisma.$subscribe
+		.customerEvent({
+			mutation_in: ['CREATED'],
+			node: {type: 'VIEWED_PROJECT'},
+		})
+		.node().$fragment(gql`
+		fragment CustomerEventWithCustomer on CustomerEvent {
+			id
+			customer {
+				id
+			}
+		}
+	`);
+
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const {
+			value: {id, customer},
+		} = await subscription.next();
+
+		const [user] = await prisma.users({
+			where: {
+				company: {
+					customers_some: {id: customer.id},
+				},
+				notifications_none: {
+					customerEvent: {type: 'VIEWED_PROJECT'},
+					createdAt_gt: moment()
+						.subtract(1, 'days')
+						.format(),
+				},
+			},
+		});
+
+		if (user) {
+			await prisma.createNotification({
+				customerEvent: {connect: {id}},
+				user: {connect: {id: user.id}},
+			});
+		}
+	}
+}
+
+module.exports = {
+	notifyViewedProject,
+};

--- a/resolvers/Query.js
+++ b/resolvers/Query.js
@@ -53,21 +53,6 @@ const Query = {
 			const hasCustomer = await ctx.db.$exists.customer({token});
 
 			if (hasCustomer) {
-				// checking if the event has already been notified
-				const [user] = await ctx.db.users({
-					where: {
-						company: {
-							customers_some: {token},
-						},
-						notifications_none: {
-							customerEvent: {type: 'VIEWED_PROJECT'},
-							createdAt_gt: moment()
-								.subtract(1, 'days')
-								.format(),
-						},
-					},
-				});
-
 				await ctx.db.createCustomerEvent({
 					type: 'VIEWED_PROJECT',
 					customer: {
@@ -75,11 +60,6 @@ const Query = {
 					},
 					metadata: {
 						projectId: project.id,
-					},
-					notifications: user && {
-						create: {
-							user: {connect: {id: user.id}},
-						},
 					},
 				});
 			}


### PR DESCRIPTION
Since queries are batched and run concurrently (there are two project queries sent when viewing the customer view), I changed the way we create the notification.